### PR TITLE
Update eligibility criteria

### DIFF
--- a/our-eligibility-criteria.md
+++ b/our-eligibility-criteria.md
@@ -1,28 +1,29 @@
 # Our Eligibility Criteria 
 
-Since the goal of the Open Source Collective is to support a Free and Open Source ecosystem, your project license is critically important. The list of [Open Source Initiative Approved License List](https://opensource.org/licenses) can serve as a gauge for valid open license criteria to the collective. Other valid licensing guidelines include the following: 
+We accept any open source project, in any language, anywhere in the world. We can also accept projects that are strongly associated with open source projects and communities like meetups and conferences, as well as advocacy groups, research, and awareness initiatives.
 
+If applying as an open source project your project license is critically important. We review licenses on a case-by-case basis when needed but licenses approved by the following bodies will significantly increase the likelihood your project will be approved:  
+
+* [Open Source Initiative Approved Licenses](https://opensource.org/licenses);
 * [Free Software Foundation License List](https://www.gnu.org/licenses/license-list.html); 
 * [Debian Free Software Guidelines](https://wiki.debian.org/DFSGLicenses); 
 * [Fedora Software License List](https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing);
 * [Open Source Hardware Association Statement of Principles](https://www.oshwa.org/definition/).
 
-We can accept any open source project, in any language, anywhere in the world. We can also accept open source related meetup groups and conferences, as well as advocacy, research, and awareness initiatives.
+We do not accept projects that are hosted under a personal profile. Please make sure your project is hosted under an profile that is not strongly associatated with an individual (i.e. an organisation account).  
 
-If you are an open source project with at least 100 stars on GitHub and at least two contributors, you will likely be immediately approved.
+If you are an open source project with an [SPDX compliant license](https://spdx.org/licenses/) with at least two maintainers, and your project is not associated with a user profile, you will be immediately approved.
 
-If you don’t fit 100 GitHub stars requirement, we will consider your application on a case by case basis, using the following criteria:
+If you don’t fit the above requirements, we will consider your application on a case by case basis, using the following criteria:
 
-Projects who don’t have their code repo on GitHub should show equivalent traction to the 100 stars requirement, whether through GitLab stars, evidence that the project is a dependency of other open source projects, or similar social validation.
+## Open source projects
+If there’s a codebase at the heart of your project, it should meet the crieria above. 
 
-User groups should have at least 50 members and be able to demonstrate a genuine history of community activity (forum, events, publications, etc).
+## User groups 
+Should have at least 50 members and be able to demonstrate a genuine history of community activity (forum, events, publications, etc).
 
-Your project must be directly related to open source, not proprietary technology or any other topics.
+## Meetups or small event groups 
+You should have organized at least 2 events previously, and be able to show a history of activity online and offline. As further evidence, you agree to send photo/video documentation of your first event after joining Open Source Collective.
 
-If there’s a codebase at the heart of your project, it should be under an open source license. (See above.)
-
-Meetups or small event groups should have organized at least 2 events previously, and be able to show a history of activity online and offline. As further evidence, you agree to send photo/video documentation of your first event after joining Open Source Collective.
-
-Conferences and larger events may require specific risk assessment by our board. No expenses will be paid in advance of sufficient funds being available in the Collective budget (e.g. hiring a venue).
-
-You understand that all agreements between your Collective and third parties, such as venues, contractors, speakers, etc, require explicit written permission and involvement of the OSC administrators. As fiscal sponsor, such agreements are legally between the third party and Open Source Collective.
+## Conferences and larger events 
+We may require specific risk assessment by our board. No expenses will be paid in advance of sufficient funds being available in the Collective budget (e.g. hiring a venue).All agreements between your Collective and third parties, such as venues, contractors, speakers, etc, require explicit written permission and involvement of the OSC administrators. As fiscal sponsor, such agreements are legally between the third party and Open Source Collective.

--- a/our-eligibility-criteria.md
+++ b/our-eligibility-criteria.md
@@ -10,9 +10,11 @@ If applying as an open source project your project license is critically importa
 * [Fedora Software License List](https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing);
 * [Open Source Hardware Association Statement of Principles](https://www.oshwa.org/definition/).
 
-We do not accept projects that are hosted under a personal profile. Please make sure your project is hosted under an profile that is not strongly associatated with an individual (i.e. an organisation account).  
+We do not accept projects that do not have a recent history of activity or an established base of dependent packages, applications or services. If your project is a fork of an existing repository there should be a material degree of activity and usage _away_ from the forked project. 
 
-If you are an open source project with an [SPDX compliant license](https://spdx.org/licenses/) with at least two maintainers, and your project is not associated with a user profile, you will be immediately approved.
+We do not accept projects that are hosted under a personal profile. Please make sure your project is hosted under an profile that is not strongly associatated with an individual (i.e. an organisation account).
+
+If you are an open source project with an [SPDX compliant license](https://spdx.org/licenses/), a recent history of activity or a current base of dependents, at least two maintainers, and your project is not associated with an individual user's profile, you will be immediately approved.
 
 If you don’t fit the above requirements, we will consider your application on a case by case basis, using the following criteria:
 


### PR DESCRIPTION
This pull request updates the eligibility criteria in the following ways:

- we remove the '100 stars' proxy for _traction_ and replace it with actual traction (usage) or a history of recent activity. 
- we add a requirement that open source projects are not strongly owned by an individual i.e. that they are set up as shared entities on the platforms that host the source code
- we provide a stronger commitment to accept projects automatically if they meet these requirement 

Are these modifications practical? 

From a technical point of view it should be possible to detect whether the project

- has an SPDX compliant licnce, and whether it matches our criteria ([github](https://docs.github.com/en/rest/reference/licenses), [gitlab](https://docs.gitlab.com/ee/api/projects.html#get-single-project))
- is owned by a user or an organisation ([github](https://docs.github.com/en/rest/reference/repos#get-a-repository), [gitlab](https://docs.gitlab.com/ee/api/projects.html))
- has a recent (12 months) history of activity ([github](https://docs.github.com/en/rest/reference/repos#get-the-last-year-of-commit-activity), [gitlab](https://docs.gitlab.com/ee/api/projects.html#get-single-project))
- is a fork of another project ([github](https://docs.github.com/en/rest/reference/repos#forks), [gitlab](https://docs.gitlab.com/ee/api/projects.html#get-single-project))

The dependents and maintainers questions are not answered by github or gitlab but Libraries.io provides both https://libraries.io/rubygems/bibliothecary

From an administration point of view, could we handle the additional traffic and could we provide an adequate degree of AML with this kind of setup? I think so, but I'm more than happy to discuss... 